### PR TITLE
Update nodepool.yaml sample to use DIB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vars.sh
 nodepool.yaml.erb
+layout.yaml

--- a/etc/nodepool/nodepool.yaml.erb.sample
+++ b/etc/nodepool/nodepool.yaml.erb.sample
@@ -1,5 +1,6 @@
 script-dir: /etc/nodepool/scripts
-
+elements-dir: /etc/nodepool/elements
+images-dir: /opt/nodepool_dib
 dburi: 'mysql://nodepool:<%= mysql_password %>@localhost/nodepool'
 
 cron:
@@ -15,17 +16,30 @@ gearman-servers:
 
 labels:
   - name: d-p-c
-    image: d-p-c
+    image: dpc
     min-ready: 2
     providers:
       - name: local_01
 
   - name: d-p-c-fc
-    image: d-p-c-fc
+    image: dpc
     min-ready: 1
     providers:
       - name: local_01_fc
 
+diskimages:
+    - name: dpc
+      elements:
+        - ubuntu
+        - vm
+        - openstack-repos
+        - puppet
+        - nodepool-base
+        - node-devstack
+      release: trusty
+      env-vars:
+        TMPDIR: /opt/dib_tmp
+        DIB_IMAGE_CACHE: /opt/dib_cache
 
 providers:
   - name: local_01
@@ -34,24 +48,15 @@ providers:
     auth-url: 'http://localhost:5000/v2.0'
     project-id: 'admin'
     max-servers: 2
-    #This keypair is used to create the image and should be found in the cloud keypairs.
-    #The public/private parts of this keypair need to be in the user who's running nodepool ~/.ssh/id_rsa
-    #You can then login to vm's e.g. ubuntu username using this
-    keypair: 'jenkins'
     images:
-      - name: d-p-c
-        # This is the image name to use found in this provider's `glance image-list`
-        base-image: '<%= provider_image_name %>'
+      - name: dpc
         min-ram: 8192
-        # This is the script that will be used to prepare the image
-        setup: <%= provider_image_setup_script_name %>
-        #Set the public key part only of the jenkin's key (no whitespace) to the NODEPOOL_SSH_KEY environment variable in order to
-        #inject it into the image's jenkins user .ssh/authorized_keys
-        #This key will be used to log in and setup jenkins on the target VM
+        diskimage: dpc
+        username: jenkins
         private-key: '/home/nodepool/.ssh/id_rsa'
 
-# Due to the nature of FC passthrough, at most one node per blade can be enabled.
-# To acheive this with nodepool, create a "new" provider with max-server : 1
+# Due to the nature of FC passthrough, at most n nodes per blade can be enabled.
+# To acheive this with nodepool, create a "new" provider with max-server : n
 # and this single image.
   - name: local_01_fc
     username: '<%= provider_username %>'
@@ -59,12 +64,11 @@ providers:
     auth-url: 'http://localhost:5000/v2.0'
     project-id: 'admin'
     max-servers: 1
-    keypair: 'jenkins'
     images:
-      - name: d-p-c-fc
-        base-image: '<%= provider_image_name %>'
+      - name: dpc
         min-ram: 8192
-        setup: <%= provider_image_setup_script_name %>
+        diskimage: dpc
+        username: jenkins
         private-key: '/home/nodepool/.ssh/id_rsa'
 
 targets:


### PR DESCRIPTION
Disk Image Builder (DIB) is a superior method of building and maintaining
images for nodepool in every regard. It's faster, more reliable,
simpler to debug, simpler to maintain, and scalable. Update the sample
to only use DIB.

Change-Id: Idfaa619741b7f56654df707f734fb32339cd1144
