### PR TITLE
Replace tempest.api.volume with volume as default

### DIFF
--- a/etc/jenkins_jobs/config/dsvm-cinder-driver.yaml.sample
+++ b/etc/jenkins_jobs/config/dsvm-cinder-driver.yaml.sample
@@ -55,7 +55,7 @@
           export PYTHONUNBUFFERED=true
           export DEVSTACK_GATE_TIMEOUT=120
           export DEVSTACK_GATE_TEMPEST=1
-          export DEVSTACK_GATE_TEMPEST_REGEX="tempest.api.volume."
+          export DEVSTACK_GATE_TEMPEST_REGEX="volume"
 
           # Let's use the http protocol instead of git protocol
           # export GIT_BASE="http://github.com"


### PR DESCRIPTION
One liner discussed on openstack-cinder channel, save newbies a little time by putting in less restrictive Tempest regex.
